### PR TITLE
Guild Endpoints

### DIFF
--- a/api/guild.go
+++ b/api/guild.go
@@ -241,8 +241,11 @@ type GuildMember struct {
 	Deaf                       bool        `json:"deaf"`                                   // Deaf - whether the user is deafened in voice channels
 	Mute                       bool        `json:"mute"`                                   // Mute - whether the user is muted in voice channels
 	Pending                    bool        `json:"pending,omitempty"`                      // Pending - whether the user has not yet passed the guild's Membership Screening requirements
-	Permissions                string      `json:"permissions,omitempty"`                  // Permissions - total permissions of the member in the channel, including overwrites, returned when in the interaction object
 	CommunicationDisabledUntil *time.Time  `json:"communication_disabled_until,omitempty"` // CommunicationDisabledUntil - when the user's timeout will expire and the user will be able to communicate in the guild again, null or a time in the past if the user is not timed out
+
+	// Undocumented as of 12/3/2022
+	Flags     UserFlags `json:"flags,omitempty"`
+	IsPending bool      `json:"is_pending,omitempty"`
 }
 
 // Integration - a guild integration

--- a/api/guild_endpoints.go
+++ b/api/guild_endpoints.go
@@ -233,7 +233,7 @@ func (g *Guild) GetGuildMember(userID Snowflake) (*GuildMember, error) {
 // ListGuildMembers - Returns a list of guild member objects that are members of the guild.
 //
 // This endpoint is restricted according to whether the GuildMembers Privileged Intent is enabled for your application.
-func (g *Guild) ListGuildMembers(limit *uint64, after *Snowflake) (*[]GuildMember, error) {
+func (g *Guild) ListGuildMembers(limit *uint64, after *Snowflake) ([]*GuildMember, error) {
 	u := parseRoute(fmt.Sprintf(listGuildMembers, api, g.ID.String()))
 
 	q := u.Query()
@@ -247,7 +247,7 @@ func (g *Guild) ListGuildMembers(limit *uint64, after *Snowflake) (*[]GuildMembe
 		u.RawQuery = q.Encode()
 	}
 
-	var guildMembers *[]GuildMember
+	var guildMembers []*GuildMember
 	err := json.Unmarshal(fireGetRequest(u, nil, nil), &guildMembers)
 
 	return guildMembers, err


### PR DESCRIPTION
* ListGuildMembers() returns []*GuildMember rather than *[]GuildMember
* add undocumented fields to GuildMember struct

Signed-off-by: Keith Russo <keith.russo@veteransoftware.us>