### PR TITLE
Add string tag to Role Permissions

### DIFF
--- a/api/permissions.go
+++ b/api/permissions.go
@@ -715,7 +715,7 @@ type Role struct {
 	Icon         *string    `json:"icon,omitempty"`          // role icon hash
 	UnicodeEmoji *string    `json:"unicode_emoji,omitempty"` // role unicode emoji
 	Position     int        `json:"position"`                // position of this role
-	Permissions  Permission `json:"permissions"`             // permission bit set
+	Permissions  Permission `json:"permissions,string"`      // permission bit set
 	Managed      bool       `json:"managed"`                 // whether this role is managed by an integration
 	Mentionable  bool       `json:"mentionable"`             // whether this role is mentionable
 	Tags         RoleTags   `json:"tags,omitempty"`          // the tags this role has


### PR DESCRIPTION
The JSON package is having difficulties unmarshalling permissions due to them being presented by the API as a string without a string tag being present to note to the package that changes need to be made while marshalling/unmarshalling. Hence, the string tag is added under the Role object