### PR TITLE
Update copyright years and comments formatting across multiple files

### DIFF
--- a/api/application.go
+++ b/api/application.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2022-2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/application_commands.go
+++ b/api/application_commands.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2022-2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/application_commands_endpoints.go
+++ b/api/application_commands_endpoints.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2022-2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/application_role_connection_metadata.go
+++ b/api/application_role_connection_metadata.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/application_role_connection_metadata_endpoints.go
+++ b/api/application_role_connection_metadata_endpoints.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/audit_log.go
+++ b/api/audit_log.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2022-2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/audit_log_endpoints.go
+++ b/api/audit_log_endpoints.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2022-2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/auto_moderation.go
+++ b/api/auto_moderation.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2022-2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/auto_moderation_endpoints.go
+++ b/api/auto_moderation_endpoints.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/channel.go
+++ b/api/channel.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2022-2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api
@@ -67,7 +65,7 @@ type GuildTextChannel struct {
 	Flags                ChannelFlag  `json:"flags,omitempty"`                 // channel flags combined as a bitfield
 	ParentID             *Snowflake   `json:"parent_id,omitempty"`             // for guild channels: id of the parent category for a channel (each parent category can contain up to 50 channels), for threads: id of the text channel this thread was created
 	Topic                *string      `json:"topic,omitempty"`                 // the channel topic (0-1024 characters)
-	GuildID              Snowflake    `json:"guild_id,omitempty"`              // the id of the guild (may be missing for some channel objects received over gateway guild dispatches)
+	GuildID              Snowflake    `json:"guild_id,omitempty"`              // the id of the guild (maybe missing for some channel objects received over gateway guild dispatches)
 	PermissionOverwrites []*Overwrite `json:"permission_overwrites,omitempty"` // explicit permission overwrites for members and roles
 	LastPinTimestamp     *time.Time   `json:"last_pin_timestamp,omitempty"`    // when the last pinned message was pinned. This may be null in events such as GUILD_CREATE when a message is not pinned.
 	RateLimitPerUser     int64        `json:"rate_limit_per_user,omitempty"`   // amount of seconds a user has to wait before sending another Message (0-21600); bots, as well as users with the permission ManageMessages or ManageChannels, are unaffected

--- a/api/channel_api.go
+++ b/api/channel_api.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2022-2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/channel_endpoints.go
+++ b/api/channel_endpoints.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2022-2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/emoji.go
+++ b/api/emoji.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2022-2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/emoji_endpoints.go
+++ b/api/emoji_endpoints.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2022-2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/gateway.go
+++ b/api/gateway.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2022-2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/guild.go
+++ b/api/guild.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2022-2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/guild_endpoints.go
+++ b/api/guild_endpoints.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2022-2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/guild_scheduled_event.go
+++ b/api/guild_scheduled_event.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2022-2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/guild_scheduled_events_endpoints.go
+++ b/api/guild_scheduled_events_endpoints.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2022-2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/guild_template.go
+++ b/api/guild_template.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2022-2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/guild_template_endpoints.go
+++ b/api/guild_template_endpoints.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2022-2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/interactions.go
+++ b/api/interactions.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2022-2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/invite.go
+++ b/api/invite.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2022. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/invite_endpoints.go
+++ b/api/invite_endpoints.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2022-2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/message_components.go
+++ b/api/message_components.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2022. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/message_components_api.go
+++ b/api/message_components_api.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2022. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/message_components_api_test.go
+++ b/api/message_components_api_test.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2022-2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/permissions.go
+++ b/api/permissions.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2022-2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/rate_limits.go
+++ b/api/rate_limits.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2022. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/reference.go
+++ b/api/reference.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2022-2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/rest.go
+++ b/api/rest.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2022-2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/routes.go
+++ b/api/routes.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2022-2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/settings.go
+++ b/api/settings.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2022-2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/snowflake.go
+++ b/api/snowflake.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/stage_instance.go
+++ b/api/stage_instance.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2022-2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/stage_instance_endpoints.go
+++ b/api/stage_instance_endpoints.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/sticker.go
+++ b/api/sticker.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2022-2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/sticker_endpoints.go
+++ b/api/sticker_endpoints.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/teams.go
+++ b/api/teams.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2022-2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/user.go
+++ b/api/user.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2022-2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/user_endpoints.go
+++ b/api/user_endpoints.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2022-2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/voice.go
+++ b/api/voice.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2022-2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/voice_endpoints.go
+++ b/api/voice_endpoints.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2022-2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/webhook.go
+++ b/api/webhook.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2022-2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/api/webhook_endpoints.go
+++ b/api/webhook_endpoints.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2022-2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package api

--- a/errors/messages.go
+++ b/errors/messages.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package errors

--- a/gateway/close_codes.go
+++ b/gateway/close_codes.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package gateway

--- a/gateway/events/receive/application_commands/events.go
+++ b/gateway/events/receive/application_commands/events.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package application_commands

--- a/gateway/events/receive/automod/events.go
+++ b/gateway/events/receive/automod/events.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package automod

--- a/gateway/events/receive/channels/events.go
+++ b/gateway/events/receive/channels/events.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package channels

--- a/gateway/events/receive/events.go
+++ b/gateway/events/receive/events.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package receive

--- a/gateway/events/receive/guild_scheduled_events/events.go
+++ b/gateway/events/receive/guild_scheduled_events/events.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package guild_scheduled_events

--- a/gateway/events/receive/guilds/events.go
+++ b/gateway/events/receive/guilds/events.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package guilds

--- a/gateway/events/receive/integrations/events.go
+++ b/gateway/events/receive/integrations/events.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package integrations

--- a/gateway/events/receive/interactions/events.go
+++ b/gateway/events/receive/interactions/events.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package interactions

--- a/gateway/events/receive/invites/events.go
+++ b/gateway/events/receive/invites/events.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package invites

--- a/gateway/events/receive/messages/events.go
+++ b/gateway/events/receive/messages/events.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package messages

--- a/gateway/events/receive/presence/events.go
+++ b/gateway/events/receive/presence/events.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package presence

--- a/gateway/events/receive/stage_instance/events.go
+++ b/gateway/events/receive/stage_instance/events.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package stage_instance

--- a/gateway/events/receive/voice/events.go
+++ b/gateway/events/receive/voice/events.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package voice

--- a/gateway/events/receive/webhooks/events.go
+++ b/gateway/events/receive/webhooks/events.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package webhooks

--- a/gateway/events/send/events.go
+++ b/gateway/events/send/events.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package send

--- a/gateway/events/types.go
+++ b/gateway/events/types.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package events

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package gateway

--- a/gateway/intents.go
+++ b/gateway/intents.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package gateway

--- a/gateway/op_codes.go
+++ b/gateway/op_codes.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package gateway

--- a/main.go
+++ b/main.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2022-2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package main

--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2022-2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package oauth2

--- a/utilities/constants.go
+++ b/utilities/constants.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package utilities

--- a/utilities/utils.go
+++ b/utilities/utils.go
@@ -1,17 +1,15 @@
 /*
- * Copyright (c) 2022-2023. Veteran Software
+ * Copyright (c) 2022-2024. Veteran Software
  *
- * Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
+ *  Discord API Wrapper - A custom wrapper for the Discord REST API developed for a proprietary project.
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ *  License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/>.
+ *  You should have received a copy of the GNU General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package utilities


### PR DESCRIPTION
This commit updates the copyright years from "2023" to "2022-2024". It also adjusts the formatting of the project description and licensing comments in multiple files, including the main application file and several utility and event handling files.